### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ text = "Angela Merkel is a politician in Germany and leader of the CDU"
 hypothesis_template = "This example is about {}"
 classes_verbalized = ["politics", "economy", "entertainment", "environment"]
 zeroshot_classifier = pipeline("zero-shot-classification", model="MoritzLaurer/deberta-v3-large-zeroshot-v1.1-all-33")
-output = zeroshot_classifier(text, classes_verbalised, hypothesis_template=hypothesis_template, multi_label=False)
+output = zeroshot_classifier(text, classes_verbalized, hypothesis_template=hypothesis_template, multi_label=False)
 print(output)
 ```
 


### PR DESCRIPTION
![image](https://github.com/MoritzLaurer/zeroshot-classifier/assets/26504141/08eaa319-62cc-4346-a1ff-4a287a544b51)
